### PR TITLE
Implement confirmation dialog for employee deletion AB#67

### DIFF
--- a/Delete confirmation
+++ b/Delete confirmation
@@ -1,0 +1,5 @@
+Deleting an employee previously required nothing more than a single click, making accidental removals far too easy.
+
+A confirmation dialog has now been added before deletion is executed. Users must explicitly confirm the action, reducing the risk of unintended data loss.
+
+The dialog clearly communicates the consequence of the action, and users can safely cancel if the deletion was triggered by mistake. Employees are no longer sent into oblivion without a second thought.

--- a/Highlight recently updated employee cards
+++ b/Highlight recently updated employee cards
@@ -1,1 +1,0 @@
-Users have no visual indication when an employee record has been recently updated. This makes it harder to track changes.

--- a/Highlight recently updated employee cards
+++ b/Highlight recently updated employee cards
@@ -1,0 +1,1 @@
+Users have no visual indication when an employee record has been recently updated. This makes it harder to track changes.


### PR DESCRIPTION
Added a confirmation dialog before employee deletion to prevent accidental removals. Users must confirm their action, reducing the risk of unintended data loss.

Integration
Azure Boards: Linked to Work Item [AB#67](https://dev.azure.com/amk1006456/f8c242d7-a24d-4b95-9742-94b1e7bf1212/_workitems/edit/67)
GitHub: Closes Issue #